### PR TITLE
Allowing for chained follows by extending the Promise.

### DIFF
--- a/lib/resource.js
+++ b/lib/resource.js
@@ -90,7 +90,7 @@ Resource.prototype = {
    */
   follow: function(rel) {
 
-    return this.links().then(function(links) {
+    var result = this.links().then(function(links) {
 
       var link = links.find(function(link) {
         return link.rel === rel;
@@ -104,6 +104,22 @@ Resource.prototype = {
       );
 
     }.bind(this));
+
+    /*
+     * We're adding a follow() function on the result Promise. This makes it
+     * super easy to quickly follow a chain of links.
+     */
+    result.follow = function(rel) {
+
+      return result.then(function(resource) {
+
+        return resource.follow(rel);
+
+      });
+
+    };
+
+    return result;
 
   },
 

--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,37 @@ home.follow('author')
   });
 ```
 
+### Following a chain of links
+
+It's possible to follow a chain of links with follow:
+
+```js
+client.follow('rel1')
+  .then(function(resource1) {
+    return resource1.follow('rel2');
+  })
+  .then(function(resource2) {
+    return resource2.follow('rel3');
+  })
+  .then(function(resource3) {
+    console.log(resource3.getLinks());
+  });
+```
+
+As you can see, `follow()` returns a Promise. However, the returned promise
+has an additional `follow()` function itself, which makes it possible to
+shorten this to:
+
+```js
+client
+  .follow('rel1')
+  .follow('rel2')
+  .follow('rel3')
+  .then(function(resource3) {
+    console.log(resource3.getLinks());
+  });
+```
+
 ### Providing custom options
 
 restl uses [request][3] under the hood to do HTTP requests. Custom options


### PR DESCRIPTION
Instead of making the Resource thenable, I thought this might be a simpler solution. Making the resource thenable scared me a bit because it had much wider implications.

I think this at least solves the basic problem we ran into... maybe it's enough. This repo desperately needs some unittest but curious to your thoughts @pschwyter.