### PR TITLE
Added lots of request() tests,

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,12 @@
 ChangeLog
 =========
 
+0.1.3 (2017-??-??)
+------------------
+
+* #25: the resourceCache was accidentally shared between Client instances.
+
+
 0.1.2 (2017-04-19)
 ------------------
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -5,6 +5,8 @@ var package = require('../package.json');
 
 var Client = function(bookMark, requestOptions) {
 
+  this.resourceCache = {};
+
   if (typeof requestOptions === 'undefined') {
     requestOptions = {};
   }
@@ -36,7 +38,7 @@ Client.prototype = {
    * ensure that if the same resource is requested twice, the same object is
    * returned.
    */
-  resourceCache : {},
+  resourceCache : null,
 
   /**
    * Returns a resource by its uri.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restl",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Opiniated HAL client.",
   "main": "lib/index.js",
   "scripts": {

--- a/test/fixtures/hal-collection.json
+++ b/test/fixtures/hal-collection.json
@@ -10,7 +10,9 @@
               "self" : { "href" : "/hal1.json" },
               "next" : { "href" : "/hal2.json" },
               "collection" : { "href" : "/hal-collection.json" },
-              "headerTest": { "href" : "/headers" }
+              "headerTest": { "href" : "/headers" },
+              "error400" : { "href" : "/error/400" },
+              "redirect" : { "href" : "/redirect" }
             },
             "title"  : "Hal 1",
             "foo" : "bar"

--- a/test/fixtures/hal1.json
+++ b/test/fixtures/hal1.json
@@ -3,7 +3,10 @@
         "self" : { "href" : "/hal1.json" },
         "next" : { "href" : "/hal2.json" },
         "collection" : { "href" : "/hal-collection.json" },
-        "headerTest": { "href" : "/headers" }
+        "headerTest": { "href" : "/headers" },
+        "error400" : { "href" : "/error/400" },
+        "redirect" : { "href" : "/redirect" },
+        "echo": { "href" : "/echo" }
     },
     "title"  : "Hal 1",
     "foo" : "bar"

--- a/test/integration/put.js
+++ b/test/integration/put.js
@@ -33,4 +33,10 @@ describe('Issuing a PUT request', async () => {
     
   });
 
+  after( async() => {
+
+    await client.getResource('/reset').post({});
+
+  });
+
 });

--- a/test/integration/request-api.js
+++ b/test/integration/request-api.js
@@ -1,0 +1,118 @@
+const Client = require('../../lib/client');
+const Resource = require('../../lib/resource');
+const expect = require('chai').expect;
+
+describe('The Request API', async () => {
+
+  const client = new Client('http://localhost:3000/hal1.json');
+  const resource = client.getResource();
+
+  it('should work', async() => {
+
+    const result = await resource.request({
+      method: 'GET'
+    });
+    expect(result.statusCode).to.eql(200);
+    expect(result.headers).to.have.property('content-type');
+    expect(result.headers['content-type']).to.eql('application/json; charset=utf-8');
+
+  });
+
+  it('should throw an exception if there was an http error', async() => {
+
+    let ok = false;
+    try {
+      const result = await resource.follow('error400').request({
+        method: 'GET'
+      });
+    } catch (e) {
+      ok = true; 
+    }
+    expect(ok).to.eql(true);
+
+  });
+
+  it('should return the http error information if simple:false', async() => {
+
+    const result = await (await resource.follow('error400')).request({
+      method: 'GET',
+      simple: false
+    });
+    expect(result.statusCode).to.eql(400);
+
+  });
+
+  it('should follow redirects', async() => {
+
+    const result = await (await resource.follow('redirect')).request({
+      method: 'GET'
+    });
+    expect(result.statusCode).to.eql(200);
+    expect(result.headers['content-type']).to.eql('application/json; charset=utf-8');
+
+  });
+
+  it('should not follow redirects when followRedirect:false', async() => {
+
+    const result = await (await resource.follow('redirect')).request({
+      method: 'GET',
+      followRedirect: false,
+      simple: false
+    });
+    expect(result.statusCode).to.eql(302);
+    expect(result.headers).to.have.property('location');
+
+  });
+
+  it('should set headers when requested', async() => {
+
+    const result = await (await resource.follow('headerTest')).request({
+      method: 'GET',
+      headers: {
+        accept: 'application/foo-bar'
+      }
+    });
+
+    expect(result.body).to.have.property('accept');
+    expect(result.body.accept).to.eql('application/foo-bar');
+
+  });
+
+  it('should understand the auth.bearer setting');
+
+  it('should allow posting json', async() => {
+
+    const echo = await resource.follow('echo');
+    const result = await echo.request({
+      method: 'POST',
+      encoding: null,
+      body: {foo: 'bar'}
+    });
+
+    expect(result.statusCode).to.eql(200);
+    expect(result.headers['content-type']).to.eql('application/json; charset=utf-8');
+    expect(result.body).to.eql({foo: 'bar'});
+
+  });
+
+  it('should allow uploading binaries', async() => {
+
+    const echo = await resource.follow('echo');
+    const result = await echo.request({
+      method: 'POST',
+      json: false,
+      encoding: null,
+      headers: {
+        'Content-Type': 'application/octet-binary'
+      },
+      body: Buffer.from('hello world')
+    });
+
+    expect(result.statusCode).to.eql(200);
+    expect(result.headers['content-type']).to.eql('application/octet-binary');
+    expect(result.body).to.be.an.instanceof(Buffer);
+    expect(result.body.toString()).to.eql('hello world');
+
+  });
+
+});

--- a/test/testserver.js
+++ b/test/testserver.js
@@ -29,6 +29,33 @@ app.use(
   })
 );
 
+// HTTP errors as a service
+app.use(
+  route('/error/:code')
+  .get(ctx => {
+     ctx.response.status = parseInt(ctx.params.code);
+     ctx.response.body = '';
+  })
+);
+
+// Redirect testing
+app.use(
+  route('/redirect')
+  .get(ctx => {
+    ctx.response.redirect('/hal2.json');
+  })
+);
+
+
+// Return request body as we received it
+app.use(
+  route('/echo')
+  .post(ctx => {
+    ctx.response.statusCode = 200;
+    ctx.response.type = ctx.request.headers['content-type'];
+    ctx.response.body = ctx.req;
+  })
+);
 
 // Rest stuff!
 app.use(


### PR DESCRIPTION
These tests will help in making a simple BC layer, which will eventually allow us to complete #11 / #14 in a non-breaking way.

In the process, I also found a bug that caused every instance of Client to
share the instance of its resourceCache. This is now fixed.